### PR TITLE
Missing trailing comma on BibTeX citation.

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -346,7 +346,7 @@
     <pre><code>@inproceedings{shaham2024multimodal,
       title={A Multimodal Automated Interpretability Agent},
       author={Tamar Rott Shaham and Sarah Schwettmann and Franklin Wang and Achyuta Rajaram and Evan Hernandez and Jacob Andreas and Antonio Torralba},
-      year={2024}
+      year={2024},
       booktitle={Forty-first International Conference on Machine Learning}
     }
     </code></pre>


### PR DESCRIPTION
Hi,

Fantastic work, I enjoyed a lot the reading, congrats.

I noticed that in the citation provided in the web site, there is a trailing comma missing which causes BibTeX to skip the ICML conference from the citation.